### PR TITLE
Fixed a few warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OBJS= ${SRCS:.c=.o}
 DEPS= ${SRCS:.c=.d}
 
 LDADD+= -lcurses
-CFLAGS+= -std=c99 -Wall -Wextra -Wno-unused-function -O0 -g
+CFLAGS+= -std=gnu99 -Wall -Wextra -Wno-unused-function -O0 -g 
 
 .SUFFIXES: .c .o
 .PHONY: clean

--- a/world.c
+++ b/world.c
@@ -43,7 +43,7 @@ world_init(struct world *w)
 		cave_gen(w->levels[0]);
 		level_load(w->levels[0], "misc/entry");
 	} while (-1 == level_add_stairs(w->levels[0], false, true));
-	w->levels[0]->entrymessage = ENTRY_MSG;
+	w->levels[0]->entrymessage = (char *)ENTRY_MSG;
 	/* Generate three random caves */
 	log_debug("Generate three random caves\n");
 	for (int32_t i = 1; i < w->levelsz - 1; i++) {
@@ -57,7 +57,7 @@ world_init(struct world *w)
 	w->levels[w->levelsz - 1] = calloc(1, sizeof(struct level));
 	level_init(w->levels[w->levelsz - 1]);
 	cave_gen(w->levels[w->levelsz - 1]);
-	w->levels[w->levelsz - 1]->entrymessage = ENTRY_MSG;
+	w->levels[w->levelsz - 1]->entrymessage = (char *)ENTRY_MSG;
 	level_load(w->levels[w->levelsz - 1], "misc/hall");
 	level_add_stairs(w->levels[w->levelsz - 1], true, false);
 


### PR DESCRIPTION
A 'strsep()' and 'getline()' calls function compile with warnings on Linux. To avoid that, pass "-std=gnu99" as a command-line argument to GCC. 
```
level.c: In function ‘string_to_coordinate’:
level.c:61:9: warning: implicit declaration of function ‘strsep’; did you mean ‘strlen’? [-Wimplicit-function-declaration]
   61 |         strsep(&src, " ");
      |         ^~~~~~
      |         strlen
level.c: In function ‘level_load’:
level.c:125:33: warning: implicit declaration of function ‘getline’ [-Wimplicit-function-declaration]
  125 |         while (-1 != (linelen = getline(&line, &linez, s))) {
      |                                 ^~~~~~~
level.c:132:41: warning: comparison between pointer and integer
  132 |                 if (strsep(&linep, ":") == NULL) {
      |                                         ^~
```
Expicitly cast a defined string to "char *" to fix the following warnings.
```
world.c: In function ‘world_init’:
world.c:46:36: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   46 |         w->levels[0]->entrymessage = ENTRY_MSG;
      |                                    ^
world.c:60:49: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   60 |         w->levels[w->levelsz - 1]->entrymessage = ENTRY_MSG;
      |                                                 ^
```